### PR TITLE
typo macos compiling

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -63,10 +63,10 @@ editor binary built with ``target=release_debug``::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
+    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
 
-If you are building the ``master`` branch, additionally copy the Vulkan library:
+If you are building the ``master`` branch, additionally copy the Vulkan library::
 
     mkdir -p Godot.app/Contents/Frameworks
     cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib


### PR DESCRIPTION
Not sure about the line 66 edit but since at line 48 the output is godot.osx.tools.universal I suppose we should also use it (at least in my case I needed to)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
